### PR TITLE
Add stats view

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,6 +131,10 @@ def get_backup_info(backup_data):
 def index():
     return render_template('index.html')
 
+@app.route('/stats')
+def stats_page():
+    return render_template('stats.html')
+
 @app.route('/api/workout', methods=['GET'])
 def get_workout():
     today = datetime.now().date()
@@ -175,6 +179,11 @@ def get_stats():
         'total_calories': sum(calculate_calories(entry) for entry in all_entries)
     }
     return jsonify(total_stats)
+
+@app.route('/api/daily_stats', methods=['GET'])
+def get_daily_stats():
+    entries = WorkoutEntry.query.order_by(WorkoutEntry.date).all()
+    return jsonify([entry.to_dict() for entry in entries])
 
 @app.route('/api/reset', methods=['POST'])
 def reset_data():

--- a/templates/index.html
+++ b/templates/index.html
@@ -158,6 +158,10 @@
 </head>
 <body>
     <div class="overlay-container">
+        <nav class="mb-4">
+            <a href="/" class="btn btn-primary btn-sm">Tracker</a>
+            <a href="/stats" class="btn btn-secondary btn-sm">Stats</a>
+        </nav>
         <div class="stats-card">
             <h3 class="mb-3">Statistics</h3>
             <div class="row">

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Workout Stats</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            background-image: url('/static/background.jpg');
+            background-size: cover;
+            background-position: center;
+            background-attachment: fixed;
+            padding: 20px;
+            color: #000000;
+            min-height: 100vh;
+            font-family: 'Roboto Condensed', sans-serif;
+            text-transform: uppercase;
+        }
+        .overlay-container {
+            background-color: rgba(255, 255, 255, 0.15);
+            min-height: 100vh;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow-y: auto;
+            padding: 20px;
+        }
+        h1 {
+            color: #000000;
+            font-weight: 900;
+            margin-bottom: 30px;
+            text-shadow: 2px 2px 4px rgba(255,255,255,0.5);
+            letter-spacing: 4px;
+            font-size: 3rem;
+        }
+        table {
+            background-color: rgba(255, 255, 255, 0.25);
+        }
+        th, td {
+            color: #000000;
+        }
+    </style>
+</head>
+<body>
+<div class="overlay-container">
+    <nav class="mb-4">
+        <a href="/" class="btn btn-secondary btn-sm">Tracker</a>
+        <a href="/stats" class="btn btn-primary btn-sm">Stats</a>
+    </nav>
+    <h1 class="text-center">Overall Stats</h1>
+    <div class="table-responsive mb-4">
+        <table class="table table-bordered table-striped" id="statsTable">
+            <thead>
+            <tr>
+                <th>Date</th>
+                <th>Pull Ups</th>
+                <th>Push Ups</th>
+                <th>Sit Ups</th>
+                <th>Squats</th>
+                <th>Km Ran</th>
+                <th>Km Walked</th>
+                <th>Calories</th>
+            </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </div>
+    <div class="row" id="summary"></div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+async function loadDailyStats() {
+    const response = await fetch('/api/daily_stats');
+    const data = await response.json();
+    const tbody = document.querySelector('#statsTable tbody');
+    tbody.innerHTML = '';
+    let totalCalories = 0;
+    let activeDays = 0;
+    const weekdayCounts = Array(7).fill(0);
+    data.forEach(entry => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+            <td>${entry.date}</td>
+            <td>${entry.pull_ups}</td>
+            <td>${entry.push_ups}</td>
+            <td>${entry.sit_ups}</td>
+            <td>${entry.squats}</td>
+            <td>${entry.km_ran}</td>
+            <td>${entry.km_walked}</td>
+            <td>${Math.round(entry.calories)}</td>`;
+        tbody.appendChild(row);
+        totalCalories += entry.calories;
+        const totalMoves = entry.pull_ups + entry.push_ups + entry.sit_ups + entry.squats + entry.km_ran + entry.km_walked;
+        if (totalMoves > 0) activeDays += 1;
+        const d = new Date(entry.date);
+        weekdayCounts[d.getDay()] += 1;
+    });
+    const totalDays = data.length;
+    const avgCalories = totalDays ? Math.round(totalCalories / totalDays) : 0;
+    const weekdays = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+    const summaryDiv = document.getElementById('summary');
+    summaryDiv.innerHTML = `
+        <div class="col-md-4 mb-3"><div class="p-3 bg-light bg-opacity-25 border">Total Days: ${totalDays}</div></div>
+        <div class="col-md-4 mb-3"><div class="p-3 bg-light bg-opacity-25 border">Active Days: ${activeDays}</div></div>
+        <div class="col-md-4 mb-3"><div class="p-3 bg-light bg-opacity-25 border">Avg Calories/Day: ${avgCalories}</div></div>
+        <div class="col-12">
+            <div class="p-3 bg-light bg-opacity-25 border">
+                <strong>Entries by Weekday:</strong>
+                <ul class="mb-0">
+                    ${weekdayCounts.map((c,i)=>`<li>${weekdays[i]}: ${c}</li>`).join('')}
+                </ul>
+            </div>
+        </div>`;
+}
+
+document.addEventListener('DOMContentLoaded', loadDailyStats);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add route and template for stats view
- expose daily stats API
- link tracker and stats pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e1f9f53588322989b7715da48eb62