### PR TITLE
Add settings tab for weight and speeds

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -161,6 +161,7 @@
         <nav class="mb-4">
             <a href="/" class="btn btn-primary btn-sm">Tracker</a>
             <a href="/stats" class="btn btn-secondary btn-sm">Stats</a>
+            <a href="/settings" class="btn btn-secondary btn-sm">Settings</a>
         </nav>
         <div class="stats-card">
             <h3 class="mb-3">Statistics</h3>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Settings</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@700&display=swap" rel="stylesheet">
+    <style>
+        body {
+            background-image: url('/static/background.jpg');
+            background-size: cover;
+            background-position: center;
+            background-attachment: fixed;
+            padding: 20px;
+            color: #000000;
+            min-height: 100vh;
+            font-family: 'Roboto Condensed', sans-serif;
+            text-transform: uppercase;
+        }
+        .overlay-container {
+            background-color: rgba(255, 255, 255, 0.15);
+            min-height: 100vh;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            overflow-y: auto;
+            padding: 20px;
+        }
+        h1 {
+            color: #000000;
+            font-weight: 900;
+            margin-bottom: 30px;
+            text-shadow: 2px 2px 4px rgba(255,255,255,0.5);
+            letter-spacing: 4px;
+            font-size: 3rem;
+        }
+        label {
+            color: #000000;
+            font-weight: 700;
+        }
+    </style>
+</head>
+<body>
+<div class="overlay-container">
+    <nav class="mb-4">
+        <a href="/" class="btn btn-secondary btn-sm">Tracker</a>
+        <a href="/stats" class="btn btn-secondary btn-sm">Stats</a>
+        <a href="/settings" class="btn btn-primary btn-sm">Settings</a>
+    </nav>
+    <h1 class="text-center">User Settings</h1>
+    <form id="settingsForm" class="mx-auto" style="max-width:400px;">
+        <div class="mb-3">
+            <label for="weight" class="form-label">Weight (kg)</label>
+            <input type="number" step="0.1" class="form-control" id="weight">
+        </div>
+        <div class="mb-3">
+            <label for="walk_speed" class="form-label">Walking Speed (km/h)</label>
+            <input type="number" step="0.1" class="form-control" id="walk_speed">
+        </div>
+        <div class="mb-3">
+            <label for="run_speed" class="form-label">Running Speed (km/h)</label>
+            <input type="number" step="0.1" class="form-control" id="run_speed">
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+async function loadSettings() {
+    const res = await fetch('/api/settings');
+    if (res.ok) {
+        const data = await res.json();
+        document.getElementById('weight').value = data.weight || '';
+        document.getElementById('walk_speed').value = data.walk_speed || '';
+        document.getElementById('run_speed').value = data.run_speed || '';
+    }
+}
+
+document.getElementById('settingsForm').addEventListener('submit', async e => {
+    e.preventDefault();
+    const payload = {
+        weight: parseFloat(document.getElementById('weight').value) || 0,
+        walk_speed: parseFloat(document.getElementById('walk_speed').value) || 0,
+        run_speed: parseFloat(document.getElementById('run_speed').value) || 0
+    };
+    const res = await fetch('/api/settings/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    if (res.ok) {
+        alert('Settings saved');
+    }
+});
+
+document.addEventListener('DOMContentLoaded', loadSettings);
+</script>
+</body>
+</html>

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -50,6 +50,7 @@
     <nav class="mb-4">
         <a href="/" class="btn btn-secondary btn-sm">Tracker</a>
         <a href="/stats" class="btn btn-primary btn-sm">Stats</a>
+        <a href="/settings" class="btn btn-secondary btn-sm">Settings</a>
     </nav>
     <h1 class="text-center">Overall Stats</h1>
     <div class="table-responsive mb-4">
@@ -63,6 +64,7 @@
                 <th>Squats</th>
                 <th>Km Ran</th>
                 <th>Km Walked</th>
+                <th>Weight (kg)</th>
                 <th>Calories</th>
             </tr>
             </thead>
@@ -91,6 +93,7 @@ async function loadDailyStats() {
             <td>${entry.squats}</td>
             <td>${entry.km_ran}</td>
             <td>${entry.km_walked}</td>
+            <td>${entry.weight}</td>
             <td>${Math.round(entry.calories)}</td>`;
         tbody.appendChild(row);
         totalCalories += entry.calories;


### PR DESCRIPTION
## Summary
- support user settings in DB
- calculate running/walking calories using weight and speed
- back up and restore weight values
- new Settings page to edit weight, walking speed, and running speed
- show weight on Stats page and link to Settings

## Testing
- `python -m py_compile app.py`
- *(fails: Flask not installed)* `python app.py`

------
https://chatgpt.com/codex/tasks/task_e_684e276fc3048322bd85b4ba704abe85